### PR TITLE
Use diego logging client in place of compatibility

### DIFF
--- a/auctionmetricemitterdelegate/auction_metric_emitter_delegate.go
+++ b/auctionmetricemitterdelegate/auction_metric_emitter_delegate.go
@@ -5,14 +5,14 @@ import (
 
 	"code.cloudfoundry.org/auction/auctiontypes"
 	"code.cloudfoundry.org/auctioneer"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 )
 
 type auctionMetricEmitterDelegate struct {
-	metronClient loggregator_v2.IngressClient
+	metronClient loggingclient.IngressClient
 }
 
-func New(metronClient loggregator_v2.IngressClient) auctionMetricEmitterDelegate {
+func New(metronClient loggingclient.IngressClient) auctionMetricEmitterDelegate {
 	return auctionMetricEmitterDelegate{
 		metronClient: metronClient,
 	}

--- a/auctionmetricemitterdelegate/auctionmetricemitterdelegate_test.go
+++ b/auctionmetricemitterdelegate/auctionmetricemitterdelegate_test.go
@@ -6,7 +6,7 @@ import (
 	"code.cloudfoundry.org/auction/auctiontypes"
 	"code.cloudfoundry.org/auctioneer/auctionmetricemitterdelegate"
 	"code.cloudfoundry.org/bbs/models"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/rep"
 
 	. "github.com/onsi/ginkgo"

--- a/cmd/auctioneer/config/config.go
+++ b/cmd/auctioneer/config/config.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/debugserver"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/durationjson"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager/lagerflags"
 	"code.cloudfoundry.org/locket"
 )
@@ -28,7 +28,7 @@ type AuctioneerConfig struct {
 	ListenAddress                 string                `json:"listen_address,omitempty"`
 	LockRetryInterval             durationjson.Duration `json:"lock_retry_interval,omitempty"`
 	LockTTL                       durationjson.Duration `json:"lock_ttl,omitempty"`
-	LoggregatorConfig             loggregator_v2.Config `json:"loggregator"`
+	LoggregatorConfig             loggingclient.Config  `json:"loggregator"`
 	RepCACert                     string                `json:"rep_ca_cert,omitempty"`
 	RepClientCert                 string                `json:"rep_client_cert,omitempty"`
 	RepClientKey                  string                `json:"rep_client_key,omitempty"`

--- a/cmd/auctioneer/config/config_test.go
+++ b/cmd/auctioneer/config/config_test.go
@@ -8,8 +8,8 @@ import (
 
 	"code.cloudfoundry.org/auctioneer/cmd/auctioneer/config"
 	"code.cloudfoundry.org/debugserver"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/durationjson"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager/lagerflags"
 	"code.cloudfoundry.org/locket"
 
@@ -117,7 +117,7 @@ var _ = Describe("AuctioneerConfig", func() {
 			ListenAddress:     "0.0.0.0:9090",
 			LockRetryInterval: durationjson.Duration(1 * time.Minute),
 			LockTTL:           durationjson.Duration(20 * time.Second),
-			LoggregatorConfig: loggregator_v2.Config{
+			LoggregatorConfig: loggingclient.Config{
 				UseV2API:      true,
 				APIPort:       1234,
 				CACertPath:    "ca-path",

--- a/cmd/auctioneer/main.go
+++ b/cmd/auctioneer/main.go
@@ -22,7 +22,7 @@ import (
 	"code.cloudfoundry.org/cfhttp"
 	"code.cloudfoundry.org/consuladapter"
 	"code.cloudfoundry.org/debugserver"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/go-loggregator/runtimeemitter"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerflags"
@@ -179,7 +179,7 @@ func main() {
 	logger.Info("exited")
 }
 
-func initializeAuctionRunner(logger lager.Logger, cfg config.AuctioneerConfig, bbsClient bbs.InternalClient, metronClient loggregator_v2.IngressClient) auctiontypes.AuctionRunner {
+func initializeAuctionRunner(logger lager.Logger, cfg config.AuctioneerConfig, bbsClient bbs.InternalClient, metronClient loggingclient.IngressClient) auctiontypes.AuctionRunner {
 	httpClient := cfhttp.NewClient()
 	stateClient := cfhttp.NewCustomTimeoutClient(time.Duration(cfg.CellStateTimeout))
 	repTLSConfig := &rep.TLSConfig{
@@ -212,8 +212,8 @@ func initializeAuctionRunner(logger lager.Logger, cfg config.AuctioneerConfig, b
 	)
 }
 
-func initializeMetron(logger lager.Logger, cfg config.AuctioneerConfig) (loggregator_v2.IngressClient, error) {
-	client, err := loggregator_v2.NewIngressClient(cfg.LoggregatorConfig)
+func initializeMetron(logger lager.Logger, cfg config.AuctioneerConfig) (loggingclient.IngressClient, error) {
+	client, err := loggingclient.NewIngressClient(cfg.LoggregatorConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -7,12 +7,12 @@ import (
 	"code.cloudfoundry.org/auction/auctiontypes"
 	"code.cloudfoundry.org/auctioneer"
 	"code.cloudfoundry.org/bbs/handlers/middleware"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/lager"
 	"github.com/tedsuo/rata"
 )
 
-func New(logger lager.Logger, runner auctiontypes.AuctionRunner, metronClient loggregator_v2.IngressClient) http.Handler {
+func New(logger lager.Logger, runner auctiontypes.AuctionRunner, metronClient loggingclient.IngressClient) http.Handler {
 	taskAuctionHandler := logWrap(NewTaskAuctionHandler(runner).Create, logger)
 	lrpAuctionHandler := logWrap(NewLRPAuctionHandler(runner).Create, logger)
 
@@ -49,7 +49,7 @@ func logWrap(loggable func(http.ResponseWriter, *http.Request, lager.Logger), lo
 
 type auctioneerEmitter struct {
 	logger       lager.Logger
-	metronClient loggregator_v2.IngressClient
+	metronClient loggingclient.IngressClient
 }
 
 func (e *auctioneerEmitter) IncrementCounter(delta int) {

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -9,7 +9,7 @@ import (
 	fake_auction_runner "code.cloudfoundry.org/auction/auctiontypes/fakes"
 	"code.cloudfoundry.org/auctioneer"
 	"code.cloudfoundry.org/auctioneer/handlers"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/rep"


### PR DESCRIPTION
This work upgrades Diego to use go-loggregator v3.0.0. It also encapsulates Diego's use of the loggregator client behind a single interface found in `diego-logging-client` within `diego-release`.

By wrapping go-loggregator in Diego, we ensure future upgrades to go-loggregator will not require such large change sets.

This PR goes hand in hand with the following PRs:
- [diego-release](https://github.com/cloudfoundry/diego-release/pull/349)
- [bbs](https://github.com/cloudfoundry/bbs/pull/24)
- [benchmarkbbs](https://github.com/cloudfoundry/benchmarkbbs/pull/3)
- [locket](https://github.com/cloudfoundry/locket/pull/3)
- [rep](https://github.com/cloudfoundry/rep/pull/17)
- [executor](https://github.com/cloudfoundry/executor/pull/27)
- [volman](https://github.com/cloudfoundry/volman/pull/4)

[#148451433]

Signed-off-by: Jason Keene <jkeene@pivotal.io>