### PR TITLE
add support for BinPackFirstFitWeight

### DIFF
--- a/cmd/auctioneer/config/config.go
+++ b/cmd/auctioneer/config/config.go
@@ -20,6 +20,7 @@ type AuctioneerConfig struct {
 	BBSClientSessionCacheSize       int                   `json:"bbs_client_session_cache_size,omitempty"`
 	BBSMaxIdleConnsPerHost          int                   `json:"bbs_max_idle_conns_per_host,omitempty"`
 	CACertFile                      string                `json:"ca_cert_file,omitempty"`
+	BinPackFirstFitWeight           float64               `json:"bin_pack_first_fit_weight,omitempty"`
 	CellStateTimeout                durationjson.Duration `json:"cell_state_timeout,omitempty"`
 	CommunicationTimeout            durationjson.Duration `json:"communication_timeout,omitempty"`
 	ConsulCluster                   string                `json:"consul_cluster,omitempty"`

--- a/cmd/auctioneer/config/config_test.go
+++ b/cmd/auctioneer/config/config_test.go
@@ -29,6 +29,7 @@ var _ = Describe("AuctioneerConfig", func() {
 			"bbs_client_session_cache_size": 100,
 			"bbs_max_idle_conns_per_host": 10,
 			"ca_cert_file": "/path-to-cert",
+			"bin_pack_first_fit_weight": 0.0,
 			"cell_state_timeout": "2s",
 			"communication_timeout": "15s",
 			"consul_cluster": "1.1.1.1",
@@ -99,6 +100,7 @@ var _ = Describe("AuctioneerConfig", func() {
 			BBSClientSessionCacheSize: 100,
 			BBSMaxIdleConnsPerHost:    10,
 			CACertFile:                "/path-to-cert",
+			BinPackFirstFitWeight:     0.0,
 			CellStateTimeout:          durationjson.Duration(2 * time.Second),
 			LocksLocketEnabled:        true,
 			ClientLocketConfig: locket.ClientLocketConfig{

--- a/cmd/auctioneer/main.go
+++ b/cmd/auctioneer/main.go
@@ -222,6 +222,7 @@ func initializeAuctionRunner(logger lager.Logger, cfg config.AuctioneerConfig, b
 		metricEmitter,
 		clock.NewClock(),
 		workPool,
+		cfg.BinPackFirstFitWeight,
 		cfg.StartingContainerWeight,
 		cfg.StartingContainerCountMaximum,
 	)

--- a/cmd/auctioneer/main_test.go
+++ b/cmd/auctioneer/main_test.go
@@ -116,6 +116,7 @@ var _ = Describe("Auctioneer", func() {
 
 		auctioneerConfig = config.AuctioneerConfig{
 			AuctionRunnerWorkers:          1000,
+			BinPackFirstFitWeight:         0.0,
 			CellStateTimeout:              durationjson.Duration(1 * time.Second),
 			CommunicationTimeout:          durationjson.Duration(10 * time.Second),
 			LagerConfig:                   lagerflags.DefaultLagerConfig(),


### PR DESCRIPTION
This PR is part of multiple PRs across [rep](https://github.com/cloudfoundry/rep), [auctioneer](https://github.com/cloudfoundry/auctioneer) and [auction](https://github.com/cloudfoundry/auction) to add an optional weighted bin pack first fit component to the scheduling algorithm of Cloud Foundry Diego for scheduling LRPs.

PRs/issues involved:
* [rep#30](https://github.com/cloudfoundry/rep/pull/30)
* [auctioneer#8](https://github.com/cloudfoundry/auctioneer/pull/8)
* [auction#8](https://github.com/cloudfoundry/auction/pull/8)
* [diego-release#448](https://github.com/cloudfoundry/diego-release/pull/448)

### What is this change about?

These PRs combined introduce a new setting for auctioneer:
```
diego.auctioneer.bin_pack_first_fit_weight
  description: "Factor to bias against BOSH instance index number of a cell. Instead of spreading containers equally across all cell
s, cells with a lower index number will be deployed to first when this setting is > 0. (0.0 - 1.0)"
  default: 0.0
```

When `bin_pack_first_fit_weight` is set to a value > 0, it will make diego-cells with a lower BOSH instance index number more attractive to deploy LRPs to by adding "weight x diego-cell index" to the score of a diego-cell. Diego-cells will be filled up more instead spreading the LRPs across all diego-cells equally.

Setting `bin_pack_first_fit_weight` to 0.0 (the default) will effectively disable the optional weighted bin pack first fit component. Everything still keeps working as it was previously.

### What problem it is trying to solve?

With the current deployment algorithm in diego it spreads the LRPs across all diego-cell instances equally. At Mendix we have 64GB memory diego-cells. We need to have the possibility for our customers to deploy 16G containers at all times. This means that we need to have at least 1 diego-cell with 16G memory available at all times. When the LRPs are spread equally you end up with a situation where on average 25% (16/64) of the memory on all our diego-cells is not used.

### What is the impact if the change is not made?

In our case 25% of our diego-cell resources are wasted. We have been running a diego-release with these changes on top for the past months in our production Cloud Foundry foundations. We are saving ten-thousands of $$ monthly on AWS EC2 costs.

### How should this change be described in diego-release release notes?

auctioneer
* Add an optional weighted bin pack first fit component to the scheduling algorithm of Cloud Foundry Diego for scheduling LRPs

### Please provide any contextual information.

Blog post with more information: https://cloud-infra.engineer/saving-costs-with-a-new-scheduler-in-cloud-foundry-diego/

### Tag your pair, your PM, and/or team!

I'm not sure who to tag.