### PR TITLE
Fix auctioneer logic for subsequent requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,6 +24,7 @@ type auctioneerClient struct {
 	insecureHTTPClient *http.Client
 	url                string
 	requireTLS         bool
+	reqGen             *rata.RequestGenerator
 }
 
 func NewClient(auctioneerURL string, requestTimeout time.Duration) Client {
@@ -31,7 +32,8 @@ func NewClient(auctioneerURL string, requestTimeout time.Duration) Client {
 		httpClient: cfhttp.NewClient(
 			cfhttp.WithRequestTimeout(requestTimeout),
 		),
-		url: auctioneerURL,
+		url:    auctioneerURL,
+		reqGen: rata.NewRequestGenerator(auctioneerURL, Routes),
 	}
 }
 
@@ -58,26 +60,19 @@ func NewSecureClient(auctioneerURL, caFile, certFile, keyFile string, requireTLS
 		insecureHTTPClient: insecureHTTPClient,
 		url:                auctioneerURL,
 		requireTLS:         requireTLS,
+		reqGen:             rata.NewRequestGenerator(auctioneerURL, Routes),
 	}, nil
 }
 
 func (c *auctioneerClient) RequestLRPAuctions(logger lager.Logger, lrpStarts []*LRPStartRequest) error {
 	logger = logger.Session("request-lrp-auctions")
 
-	reqGen := rata.NewRequestGenerator(c.url, Routes)
 	payload, err := json.Marshal(lrpStarts)
 	if err != nil {
 		return err
 	}
 
-	req, err := reqGen.CreateRequest(CreateLRPAuctionsRoute, rata.Params{}, bytes.NewBuffer(payload))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.doRequest(logger, req)
+	resp, err := c.createRequest(logger, CreateLRPAuctionsRoute, rata.Params{}, payload)
 	if err != nil {
 		return err
 	}
@@ -93,20 +88,12 @@ func (c *auctioneerClient) RequestLRPAuctions(logger lager.Logger, lrpStarts []*
 func (c *auctioneerClient) RequestTaskAuctions(logger lager.Logger, tasks []*TaskStartRequest) error {
 	logger = logger.Session("request-task-auctions")
 
-	reqGen := rata.NewRequestGenerator(c.url, Routes)
 	payload, err := json.Marshal(tasks)
 	if err != nil {
 		return err
 	}
 
-	req, err := reqGen.CreateRequest(CreateTaskAuctionsRoute, rata.Params{}, bytes.NewBuffer(payload))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.doRequest(logger, req)
+	resp, err := c.createRequest(logger, CreateTaskAuctionsRoute, rata.Params{}, payload)
 	if err != nil {
 		return err
 	}
@@ -119,15 +106,26 @@ func (c *auctioneerClient) RequestTaskAuctions(logger lager.Logger, tasks []*Tas
 	return nil
 }
 
-func (c *auctioneerClient) doRequest(logger lager.Logger, req *http.Request) (*http.Response, error) {
-	resp, err := c.httpClient.Do(req)
+func (c *auctioneerClient) createRequest(logger lager.Logger, route string, params rata.Params, payload []byte) (*http.Response, error) {
+	resp, err := c.doRequest(c.httpClient, false, route, params, payload)
 	if err != nil {
 		// Fall back to HTTP and try again if we do not require TLS
 		if !c.requireTLS && c.insecureHTTPClient != nil {
 			logger.Error("retrying-on-http", err)
-			req.URL.Scheme = "http"
-			return c.insecureHTTPClient.Do(req)
+			return c.doRequest(c.insecureHTTPClient, true, route, params, payload)
 		}
 	}
 	return resp, err
+}
+
+func (c *auctioneerClient) doRequest(client *http.Client, useHttp bool, route string, params rata.Params, payload []byte) (*http.Response, error) {
+	req, err := c.reqGen.CreateRequest(route, params, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if useHttp {
+		req.URL.Scheme = "http"
+	}
+	return client.Do(req)
 }


### PR DESCRIPTION
### Steps to reproduce
1. Introduce artificial sleep in the auctioneer
2. Push an app

### Expected

I should see a timeout error in the BBS logs.

### Actual

The BBS reports the following weird error:

```
{"timestamp":"1588706732.873437881","source":"bbs","message":"bbs.converge-
tasks.failed-to-request-auctions-for-pending-tasks","log_level":2,"data":
{"error":"Post http://auctioneer.service.cf.internal:9016/v1/tasks: http: 
ContentLength=37017 with Body length 0","session":"9775","task_guids":
["04da0bc2-5d83-4755-9d25-58582cb0a240","07295320-afd6-49e9-92de-
fb736a2219e2","07b24330-50bb-47f2-a897-2e07fdae59e5","07f32256-cc8e-47c4-
aac1-06f11d25eebe","08258907-ed5c-4e18-9972-66dbe815cbfc","0df98d5b-50bb-
44db....
```

**Notes**

- The client library creates the request buffer [this line](https://github.com/cloudfoundry/auctioneer/blob/cf25064c5b8e9669af83c954ab7708bbf501c57a/client.go#L102).  The buffer could be consumed in the first attempt which causes the [second request](https://github.com/cloudfoundry/auctioneer/blob/cf25064c5b8e9669af83c954ab7708bbf501c57a/client.go#L129) to have a non-zero content-length header but an empty body.
- https://stackoverflow.com/questions/31337891/net-http-http-contentlength-222-with-body-length-0