### PR TITLE
Add cell index normalisation config

### DIFF
--- a/cmd/auctioneer/config/config.go
+++ b/cmd/auctioneer/config/config.go
@@ -21,6 +21,7 @@ type AuctioneerConfig struct {
 	BBSMaxIdleConnsPerHost          int                   `json:"bbs_max_idle_conns_per_host,omitempty"`
 	CACertFile                      string                `json:"ca_cert_file,omitempty"`
 	BinPackFirstFitWeight           float64               `json:"bin_pack_first_fit_weight,omitempty"`
+	UseCellIndexNormalisation       bool                  `json:"use_cell_index_normalisation,omitempty"`
 	CellStateTimeout                durationjson.Duration `json:"cell_state_timeout,omitempty"`
 	CommunicationTimeout            durationjson.Duration `json:"communication_timeout,omitempty"`
 	ConsulCluster                   string                `json:"consul_cluster,omitempty"`

--- a/cmd/auctioneer/config/config_test.go
+++ b/cmd/auctioneer/config/config_test.go
@@ -30,6 +30,7 @@ var _ = Describe("AuctioneerConfig", func() {
 			"bbs_max_idle_conns_per_host": 10,
 			"ca_cert_file": "/path-to-cert",
 			"bin_pack_first_fit_weight": 0.1,
+			"use_cell_index_normalisation": true,
 			"cell_state_timeout": "2s",
 			"communication_timeout": "15s",
 			"consul_cluster": "1.1.1.1",
@@ -101,6 +102,7 @@ var _ = Describe("AuctioneerConfig", func() {
 			BBSMaxIdleConnsPerHost:    10,
 			CACertFile:                "/path-to-cert",
 			BinPackFirstFitWeight:     0.1,
+			UseCellIndexNormalisation: true,
 			CellStateTimeout:          durationjson.Duration(2 * time.Second),
 			LocksLocketEnabled:        true,
 			ClientLocketConfig: locket.ClientLocketConfig{

--- a/cmd/auctioneer/main.go
+++ b/cmd/auctioneer/main.go
@@ -225,6 +225,7 @@ func initializeAuctionRunner(logger lager.Logger, cfg config.AuctioneerConfig, b
 		cfg.BinPackFirstFitWeight,
 		cfg.StartingContainerWeight,
 		cfg.StartingContainerCountMaximum,
+		cfg.UseCellIndexNormalisation,
 	)
 }
 

--- a/cmd/auctioneer/main_test.go
+++ b/cmd/auctioneer/main_test.go
@@ -117,6 +117,7 @@ var _ = Describe("Auctioneer", func() {
 		auctioneerConfig = config.AuctioneerConfig{
 			AuctionRunnerWorkers:          1000,
 			BinPackFirstFitWeight:         0.0,
+			UseCellIndexNormalisation:     false,
 			CellStateTimeout:              durationjson.Duration(1 * time.Second),
 			CommunicationTimeout:          durationjson.Duration(10 * time.Second),
 			LagerConfig:                   lagerflags.DefaultLagerConfig(),


### PR DESCRIPTION
## Please provide the following information:

### What is this change about?

Introduction of a cell index normalisation mechanism to be used when `diego.auctioneer.bin_pack_first_fit_weight` > 0.

It could be enabled by setting `diego.auctioneer.use_cell_index_normalisation` to `true`. Index normalisation is decoupled from standard bin pack first fit distribution since it changes how the weight should be configured.

💡 Note - When cell index normalisation is used, in order to keep the distribution the same as before the old value of `diego.auctioneer.bin_pack_first_fit_weight` should be multiplied by `number of zones`.

### What problem it is trying to solve?

The way bin pack first-fit app distribution is currently implemented causes a misbalance in regard to cell resource utilisation between AZs when:

- there has been an upscale of the number of zones in BOSH
- `diego.auctioneer.bin_pack_first_fit_weight` > 0.

This results in stability issues (e.g. if the more utilised zone fails due to IaaS issues it could cause a longer outage).

### What is the impact if the change is not made?

There would be "silent" stability issues after a CF operator tries to upscale bosh availability zones while using a bin pack first-fit distribution.

### How should this change be described in diego-release release notes?

Introduce new cell indexing concept

### Please provide any contextual information.

All details, including a RC and an exact reproduction scenario could be found in [diego-release issue 542](https://github.com/cloudfoundry/diego-release/issues/542).

### Tag your pair, your PM, and/or team!

Just me -> [Ivan Hristov](https://github.com/IvanHristov98)
PM -> [Plamen Doychev](https://github.com/PlamenDoychev)
CF-Runtime team at SAP.
