### PR TITLE
Update go-loggregator to v9

### DIFF
--- a/cmd/auctioneer/main.go
+++ b/cmd/auctioneer/main.go
@@ -14,7 +14,7 @@ import (
 	cfhttp "code.cloudfoundry.org/cfhttp/v2"
 	"code.cloudfoundry.org/debugserver"
 	loggingclient "code.cloudfoundry.org/diego-logging-client"
-	"code.cloudfoundry.org/go-loggregator/v8/runtimeemitter"
+	"code.cloudfoundry.org/go-loggregator/v9/runtimeemitter"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagerflags"
 	"code.cloudfoundry.org/locket"

--- a/cmd/auctioneer/main_test.go
+++ b/cmd/auctioneer/main_test.go
@@ -17,7 +17,7 @@ import (
 	diego_logging_client "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/durationjson"
-	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2"
 	"code.cloudfoundry.org/lager/v3/lagerflags"
 	"code.cloudfoundry.org/locket"
 	locketrunner "code.cloudfoundry.org/locket/cmd/locket/testrunner"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Update go-loggregator/v8 to go-loggregator/v9


Backward Compatibility
---------------
Breaking Change? **No**