### PR TITLE
Remove old property: locks.locket.enabled - Diego release

### DIFF
--- a/cmd/auctioneer/config/config_test.go
+++ b/cmd/auctioneer/config/config_test.go
@@ -35,7 +35,6 @@ var _ = Describe("AuctioneerConfig", func() {
 			"listen_address": "0.0.0.0:9090",
 			"lock_retry_interval": "1m",
 			"lock_ttl": "20s",
-			"locks_locket_enabled": true,
 			"locket_address": "laksdjflksdajflkajsdf",
 			"locket_ca_cert_file": "locket-ca-cert",
 			"locket_client_cert_file": "locket-client-cert",


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Remove old property: locks.locket.enabled - Diego release


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
